### PR TITLE
added Kummer confluent hypergeometric function with tests

### DIFF
--- a/algopy/utpm/tests/test_utpm.py
+++ b/algopy/utpm/tests/test_utpm.py
@@ -431,6 +431,26 @@ class Test_Push_Forward(TestCase):
         t = UTPM.tanh(x)
         assert_array_almost_equal(t.data, (s/c).data)
 
+    def test_hyp1f1(self):
+        D,P,N,M = 5,3,4,5
+        #
+        # Check special case of exp.
+        x = UTPM(numpy.random.random((D,P,M,N)))
+        h = UTPM.hyp1f1(x, 1., 1.)
+        e = UTPM.exp(x)
+        assert_array_almost_equal(h.data, e.data)
+        #
+        # Check another special case.
+        x = UTPM(numpy.random.random((D,P,M,N)))
+        h = UTPM.hyp1f1(x, 1., 2.)
+        s = (UTPM.exp(x) - 1.) / x
+        assert_array_almost_equal(h.data, s.data)
+        #
+        # Check another special case.
+        x = UTPM(numpy.random.random((D,P,M,N)))
+        h = UTPM.hyp1f1(x, 0.5, -0.5)
+        s = UTPM.exp(x) * (1. - 2*x)
+        assert_array_almost_equal(h.data, s.data)
 
 
     def test_abs(self):

--- a/algopy/utpm/utpm.py
+++ b/algopy/utpm/utpm.py
@@ -536,6 +536,26 @@ class UTPM(Ring, RawAlgorithmsMixIn):
         cls._pb_tansec(ybar.data, zbar.data, x.data, y.data, z.data, out = xbar.data)
         return out
 
+    def hyp1f1(self, a, b):
+        """ computes y = hyp1f1(a, b, x) in UTP arithmetic"""
+
+        retval = self.clone()
+        self._hyp1f1(self.data, a, b, out = retval.data)
+        return retval
+
+    @classmethod
+    def pb_hyp1f1(cls, ybar, x, y, out=None):
+        """ computes bar y dy = bar x dx in UTP arithmetic"""
+        if out == None:
+            D,P = x.data.shape[:2]
+            xbar = x.zeros_like()
+
+        else:
+            xbar, = out
+
+        cls._pb_exp(ybar.data, x.data, y.data, out = xbar.data)
+        return out
+
 
     def sum(self, axis=None, dtype=None, out=None):
         if dtype != None or out != None:


### PR DESCRIPTION
The function is hyp1f1(x, a, b) instead of the standard argument order hyp1f1(a, b, x) because UTPM was picky about the type of the first argument to the function.
