### PR TITLE
typo fix in index.rst

### DIFF
--- a/documentation/sphinx/index.rst
+++ b/documentation/sphinx/index.rst
@@ -339,7 +339,7 @@ Additional Information:
 
 How is AlgoPy organized:
 
-.. torctree::
+.. toctree::
     :maxdepth: 1
 
     folder_structure.rst


### PR DESCRIPTION
"torctree" -> "toctree"
