### PR TITLE
fail less silently in prod()

### DIFF
--- a/algopy/compound.py
+++ b/algopy/compound.py
@@ -42,5 +42,7 @@ def prod(x, axis=None, dtype=None, out=None):
             y[0] = y[0] * xi
         return y[0]
 
-prod.__doc__ += numpy.prod.__doc__
+    else:
+        raise ValueError('don\'t know what to do with this input!')
 
+prod.__doc__ += numpy.prod.__doc__


### PR DESCRIPTION
This raises an exception so that prod() now behaves more like sum() for input that it doesn't understand (e.g. list of python integers).
