### PR TITLE
MAINT: fix errors in the scipy detection code when scipy is not installed

### DIFF
--- a/algopy/__init__.py
+++ b/algopy/__init__.py
@@ -83,7 +83,7 @@ except ImportError as e:
     raise ImportError(
         "SciPy import error (%s)\n"
         "SciPy is a requirement of AlgoPy.\n"
-        "Please install SciPy >= " + (e, min_scipy_version))
+        "Please install SciPy >= " + _min_scipy_version)
 
 if NumpyVersion(scipy.version.version) < _min_scipy_version:
     raise ImportError(


### PR DESCRIPTION
I uninstalled scipy to see what would happen when I tried to install algopy, and I found some bugs.
