### PR TITLE
Fixed dimension bug in outer function

### DIFF
--- a/algopy/utpm/utpm.py
+++ b/algopy/utpm/utpm.py
@@ -1976,7 +1976,7 @@ class UTPM(Ring, RawAlgorithmsMixIn):
             assert x_shp[:2] == y_shp[:2]
             assert len(y_shp[2:]) == 1
 
-            out_shp = x_shp + x_shp[-1:]
+            out_shp = x_shp + y_shp[-1:]
             out = cls(cls.__zeros__(out_shp, dtype = x.data.dtype))
             cls._outer( x.data, y.data, out = out.data)
 


### PR DESCRIPTION
The Numpy `outer` function accepts vectors of different length, returning a non-square matrix in that case.  But Algopy assumes that both vectors are of the same length.  I have fixed this for the UTPM/UTPM case, but it still needs to be fixed for `numpy.ndarray` instances.